### PR TITLE
ACC-154 - Prevent regen of cover letters

### DIFF
--- a/lib/accomplish/application.ex
+++ b/lib/accomplish/application.ex
@@ -21,6 +21,7 @@ defmodule Accomplish.Application do
       AccomplishWeb.Endpoint,
       AccomplishWeb.NavigationTracker,
       TwMerge.Cache,
+      Accomplish.TokenCache,
       {Registry, keys: :unique, name: Accomplish.Registry},
       {DynamicSupervisor, strategy: :one_for_one, name: Accomplish.DynamicSupervisor}
     ]

--- a/lib/accomplish/token_cache.ex
+++ b/lib/accomplish/token_cache.ex
@@ -37,6 +37,7 @@ defmodule Accomplish.TokenCache do
       context,
       :os.system_time(:millisecond) + @token_ttl
     })
+
     {:reply, :ok, state}
   end
 

--- a/lib/accomplish/token_cache.ex
+++ b/lib/accomplish/token_cache.ex
@@ -1,0 +1,75 @@
+defmodule Accomplish.TokenCache do
+  @moduledoc """
+  Manages one-time generation tokens for secure, ephemeral actions.
+  """
+
+  use GenServer
+
+  @token_ttl :timer.minutes(15)
+  @cleanup_interval :timer.minutes(5)
+  @cache_name :token_cache
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def generate_token(context) do
+    token = generate_unique_token()
+    GenServer.call(__MODULE__, {:create_token, token, context})
+    token
+  end
+
+  def validate_and_consume_token(token) do
+    GenServer.call(__MODULE__, {:validate_token, token})
+  end
+
+  @impl true
+  def init(_) do
+    :ets.new(@cache_name, [:named_table, :set, :private])
+    Process.send_after(self(), :cleanup, @cleanup_interval)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:create_token, token, context}, _from, state) do
+    :ets.insert(@cache_name, {
+      token,
+      context,
+      :os.system_time(:millisecond) + @token_ttl
+    })
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:validate_token, token}, _from, state) do
+    now = :os.system_time(:millisecond)
+
+    case :ets.lookup(@cache_name, token) do
+      [{^token, context, expiry}] when now < expiry ->
+        :ets.delete(@cache_name, token)
+        {:reply, {:ok, context}, state}
+
+      _ ->
+        {:reply, {:error, :invalid_or_expired_token}, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:cleanup, state) do
+    now = :os.system_time(:millisecond)
+
+    :ets.tab2list(@cache_name)
+    |> Enum.each(fn {token, _, expiry} ->
+      if now >= expiry do
+        :ets.delete(@cache_name, token)
+      end
+    end)
+
+    Process.send_after(self(), :cleanup, @cleanup_interval)
+    {:noreply, state}
+  end
+
+  defp generate_unique_token do
+    :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/accomplish_web/event_handlers/job_application_actions.ex
+++ b/lib/accomplish_web/event_handlers/job_application_actions.ex
@@ -10,6 +10,7 @@ defmodule AccomplishWeb.EventHandlers.JobApplicationActions do
 
   alias Accomplish.JobApplications
   alias Accomplish.CoverLetters
+  alias Accomplish.TokenCache
 
   @endpoint AccomplishWeb.Endpoint
   @router AccomplishWeb.Router
@@ -54,13 +55,15 @@ defmodule AccomplishWeb.EventHandlers.JobApplicationActions do
   @doc """
   Creates a new AI-generated cover letter and navigates to it with the AI generation flag.
   """
-  def handle_ai_cover_letter_create(socket, application) do
+  def handle_ai_cover_letter_create(socket, application, user) do
     case CoverLetters.create_cover_letter(application, %{title: "AI-generated Cover Letter"}) do
       {:ok, cover_letter} ->
+        token = TokenCache.generate_token(%{user_id: user.id, cover_letter_id: cover_letter.id})
+
         socket
         |> push_navigate(
           to:
-            ~p"/job_application/#{application.slug}/cover_letter/#{cover_letter.id}?ai_generate=true"
+            ~p"/job_application/#{application.slug}/cover_letter/#{cover_letter.id}?token=#{token}"
         )
 
       {:error, _} ->

--- a/lib/accomplish_web/live/components/job_applications_dialogs/cover_letter_dialog.ex
+++ b/lib/accomplish_web/live/components/job_applications_dialogs/cover_letter_dialog.ex
@@ -78,11 +78,12 @@ defmodule AccomplishWeb.Components.JobApplicationDialogs.CoverLetterDialog do
 
   def handle_event("create_ai_cover_letter", _params, socket) do
     application = socket.assigns.application
+    user = socket.assigns.current_user
 
     {:noreply,
      socket
      |> close_modal("cover-letter-dialog")
-     |> JobApplicationActions.handle_ai_cover_letter_create(application)}
+     |> JobApplicationActions.handle_ai_cover_letter_create(application, user)}
   end
 
   defp close_modal(socket, modal_id) do

--- a/lib/accomplish_web/live/job_applications_live/application_header.ex
+++ b/lib/accomplish_web/live/job_applications_live/application_header.ex
@@ -70,7 +70,12 @@ defmodule AccomplishWeb.JobApplicationsLive.ApplicationHeader do
       </:views>
     </.page_header>
 
-    <.live_component module={CoverLetterDialog} id="cover-letter-dialog" application={@application} />
+    <.live_component
+      module={CoverLetterDialog}
+      id="cover-letter-dialog"
+      application={@application}
+      current_user={@current_user}
+    />
     <.live_component
       module={StageDialog}
       id="stage-dialog"

--- a/lib/accomplish_web/live/job_applications_live/applications.ex
+++ b/lib/accomplish_web/live/job_applications_live/applications.ex
@@ -288,6 +288,7 @@ defmodule AccomplishWeb.JobApplicationsLive.Applications do
       module={CoverLetterDialog}
       id="cover-letter-dialog"
       application={@application_in_context}
+      current_user={@current_user}
     />
     <.live_component
       module={StageDialog}


### PR DESCRIPTION
User a token cache to ensure cover letters are only generated once and reloading the page doesn't retrigger a new cover letter ai generation.

The user must explicitly use the UI to trigger ai gen action